### PR TITLE
Handle multiple fulltext links and fields without relevant values

### DIFF
--- a/app/views/collection.scala.html
+++ b/app/views/collection.scala.html
@@ -1,70 +1,24 @@
 @(id: String, content: com.fasterxml.jackson.databind.JsonNode, home: controllers.HomeController)
 
 @import play.api.libs.json._
+@import tags._
 
 @main("Details: " + id) {
 	@defining(Json.parse(content.toString())) { parsedContent =>
 	    <h1>@((parsedContent \ "title").asOpt[String].getOrElse(id))</h1>
 	    <h2>Collection</h2>
 	    <table class='table table-striped table-condensed'>
-	        @produceRow(home.label("extent"), parsedContent \ "extent", (s:String) => None)
-	        @produceRow(home.label("creator") + " " + home.label("name"), parsedContent \ "creator" \ "name", (s:String) => None)
-	        @produceRow(home.label("creator") + " " + home.label("url"), parsedContent \ "creator" \ "url", (s:String) => Some(s))
-	        @produceRow(home.label("language"), (parsedContent \ "language"), (s:String) => None)
-	        @produceRow(home.label("isPartOf"), parsedContent \ "isPartOf", (s:String) => Some(s))
-	        @produceRow(home.label("type"), parsedContent \ "type", (s:String) => Some(s))
-	        @produceRow(home.label("otherTitleInformation"), parsedContent \ "otherTitleInformation", (s:String) => None)
-	        @produceRow(home.label("isPrimaryTopicOf"), parsedContent \ "isPrimaryTopicOf", (s:String) => Some(s))
-	        @produceRow(home.label("spatial"), parsedContent \ "spatial", (s:String) => None)
-	        @produceRow(home.label("homepage"), parsedContent \ "homepage", (s:String) => Some(s))
-	        @produceRow(home.label("subject"), (parsedContent \ "subject"), (s:String) => Some(s))
+	        @produceRow(home, home.label("extent"), parsedContent \ "extent", (s:String) => None)
+	        @produceRow(home, home.label("creator") + " " + home.label("name"), parsedContent \ "creator" \ "name", (s:String) => None)
+	        @produceRow(home, home.label("creator") + " " + home.label("url"), parsedContent \ "creator" \ "url", (s:String) => Some(s))
+	        @produceRow(home, home.label("language"), (parsedContent \ "language"), (s:String) => None)
+	        @produceRow(home, home.label("isPartOf"), parsedContent \ "isPartOf", (s:String) => Some(s))
+	        @produceRow(home, home.label("type"), parsedContent \ "type", (s:String) => Some(s))
+	        @produceRow(home, home.label("otherTitleInformation"), parsedContent \ "otherTitleInformation", (s:String) => None)
+	        @produceRow(home, home.label("isPrimaryTopicOf"), parsedContent \ "isPrimaryTopicOf", (s:String) => Some(s))
+	        @produceRow(home, home.label("spatial"), parsedContent \ "spatial", (s:String) => None)
+	        @produceRow(home, home.label("homepage"), parsedContent \ "homepage", (s:String) => Some(s))
+	        @produceRow(home, home.label("subject"), (parsedContent \ "subject"), (s:String) => Some(s))
 	    </table>
 	}
-}
-
-@produceRow(name: String, value: JsReadable, link: String => Option[String]) = {
-	@if(value.asOpt[Seq[JsValue]].isDefined){
-		@produceMultipleRows(name, value.asOpt[Seq[JsValue]].getOrElse(Seq()))
-	} else {
-		@produceSingleRow(name, value.asInstanceOf[JsLookupResult], link)
-	}
-}
-
-@produceSingleRow(name: String, value: JsLookupResult, link: String => Option[String]) = {
-    @if(value.asOpt[JsValue].isDefined){
-        @defining(value.as[String].substring(0,value.as[String].length())) { valueAsString =>
-            <tr>
-                <td class="field-label">
-                    @name
-                </td>
-                <td class="field-value">
-                    @if(!link(valueAsString).isDefined) {
-                        @home.label(valueAsString)
-                    } else {
-                        <a href="@valueAsString">@link(home.label(valueAsString)).get</a>
-                    }
-                </td>
-            </tr>
-        }
-    }
-}
-
-@produceMultipleRows(displayName: String, array: Seq[JsValue]) = {
-	<tr>
-		<td class="field-label">@displayName</td>
-          @for((value, i) <- array.zipWithIndex) {
-            @if(i == 0) {
-              <td class="field-value">
-                @home.label(value.as[String])
-              </td>
-            } else {
-              <tr>
-                <td class="field-value"></td>
-                <td class="field-value">
-                  @home.label(value.as[String])
-                 </td>
-              </tr>
-            }
-          }
-    </tr>
 }

--- a/app/views/resource.scala.html
+++ b/app/views/resource.scala.html
@@ -1,6 +1,7 @@
 @(id: String, contentPrint: com.fasterxml.jackson.databind.JsonNode, contentDigital: com.fasterxml.jackson.databind.JsonNode, home: controllers.HomeController)
 
 @import play.api.libs.json._
+@import tags._
 
 @localLink(link: String) = @{ link.replace("digitalisiertedrucke.de", request.host) }
 
@@ -10,79 +11,23 @@
     <h1>@((parsedContentPrint \ "title").asOpt[String].getOrElse(id))</h1>
     <h2>Print</h2>
     <table class='table table-striped table-condensed'>
-        @produceRow(home.label("medium"), parsedContentPrint \ "medium", (s:String) => Some(s))
-        @produceRow(home.label("bibliographicCitation"), parsedContentPrint \ "bibliographicCitation",_ => None)
-        @produceRow(home.label("fulltextOnline"), parsedContentPrint \ "fulltextOnline", (s:String) => Some(s))
-       
-        <tr>
-          <td>@home.label("type")</td>
-          @for((resourceType, i) <- (parsedContentPrint \ "type").asOpt[Seq[JsValue]].getOrElse(Seq()).zipWithIndex) {
-            @if(i == 0) {          
-              <td>
-                @home.label(resourceType.as[String])
-              </td>
-            } else {
-              <tr>
-                <td></td>
-                <td>
-                  @home.label(resourceType.as[String])
-                 </td>
-              </tr>
-            }
-          }
-        </tr>
-        
+        @produceRow(home, home.label("medium"), parsedContentPrint \ "medium", (s:String) => Some(s))
+        @produceRow(home, home.label("bibliographicCitation"), parsedContentPrint \ "bibliographicCitation",_ => None)
+        @produceRow(home, home.label("fulltextOnline"), parsedContentPrint \ "fulltextOnline", (s:String) => Some(s))
+        @produceRow(home, home.label("type"), parsedContentPrint \ "type", (s:String) => None)
     </table>
 }
 
 @defining(Json.parse(contentDigital.toString())) { parsedContentDigital =>
     <h2>Digital</h2>
     <table class='table table-striped table-condensed'>
-        @produceRow(home.label("created"), parsedContentDigital \ "created", _ => None)
-        @produceRow(home.label("publisher"), parsedContentDigital \ "publisher",_ => None)
-        @produceRow(home.label("medium"), parsedContentDigital \ "medium", (s:String) => Some(s))
-        @produceRow(home.label("fulltextOnline"), parsedContentDigital \ "fulltextOnline", (s:String) => Some(s))
-        @produceRow(home.label("type"), parsedContentDigital \ "type", (s:String) => Some(s))
-        
-        <tr>
-          <td>@home.label("isPartOf")</td>
-          @for((isPartOf, i) <- (parsedContentDigital \ "isPartOf").asOpt[Seq[JsValue]].getOrElse(Seq()).zipWithIndex) {
-            @if(i == 0) {          
-              <td>
-                <a href='@localLink(isPartOf.as[String])'>@home.label(isPartOf.as[String])</a>
-              </td>
-            } else {
-              <tr>
-                <td></td>
-                <td>
-                  <a href='@localLink(isPartOf.as[String])'>@home.label(isPartOf.as[String])</a>
-                 </td>
-              </tr>
-            }
-          }
-        </tr>
+        @produceRow(home, home.label("created"), parsedContentDigital \ "created", _ => None)
+        @produceRow(home, home.label("publisher"), parsedContentDigital \ "publisher",_ => None)
+        @produceRow(home, home.label("medium"), parsedContentDigital \ "medium", (s:String) => Some(s))
+        @produceRow(home, home.label("fulltextOnline"), parsedContentDigital \ "fulltextOnline", (s:String) => Some(s))
+        @produceRow(home, home.label("type"), parsedContentDigital \ "type", (s:String) => Some(s))
+        @produceRow(home, home.label("isPartOf"), parsedContentDigital \ "isPartOf", (s:String) => Some(s))
     </table>
 }
 
-}
-
-@produceRow(name: String, value: JsLookupResult, link: String => Option[String]) = {
-    @if(value.asOpt[JsValue].isDefined){
-        @defining(value.as[String].substring(0,value.as[String].length())) { valueAsString =>
-            @if(home.label(valueAsString) != "") {
-                <tr>
-                    <td class="field-label">
-                        @name
-                    </td>
-                    <td class="field-value">
-                        @if(!link(valueAsString).isDefined) {
-                            @home.label(valueAsString)
-                        } else {
-                            <a href="@valueAsString">@link(home.label(valueAsString)).get</a>
-                        }
-                    </td>
-                </tr>
-            }
-        }
-    }
 }

--- a/app/views/tags/produceRow.scala.html
+++ b/app/views/tags/produceRow.scala.html
@@ -1,0 +1,52 @@
+@(home: controllers.HomeController, name: String, value: play.api.libs.json.JsReadable, link: String => Option[String])
+
+@import play.api.libs.json._
+
+@if(value.asOpt[Seq[JsValue]].isDefined){
+	@produceMultipleRows(name, value.asOpt[Seq[JsValue]].getOrElse(Seq()))
+} else {
+	@produceSingleRow(name, value.asInstanceOf[JsLookupResult], link)
+}
+
+@fieldValue(s: String) = {
+	@if(!link(s).isDefined) {
+		@home.label(s)
+	} else {
+		<a href="@s">@link(home.label(s)).get</a>
+	}
+}
+
+@produceSingleRow(name: String, value: JsLookupResult, link: String => Option[String]) = {
+	@if(value.asOpt[String].isDefined && !home.label(value.as[String]).isEmpty){
+		@defining(value.as[String]) { valueAsString =>
+			<tr>
+				<td class="field-label">
+					@name
+				</td>
+				<td class="field-value">
+					@fieldValue(valueAsString)
+				</td>
+			</tr>
+		}
+	}
+}
+
+@produceMultipleRows(displayName: String, array: Seq[JsValue]) = {
+	<tr>
+		<td class="field-label">@displayName</td>
+			@for((value, i) <- array.zipWithIndex; if value.asOpt[String].isDefined && !home.label(value.as[String]).isEmpty) {
+				@if(i == 0) {
+					<td class="field-value">
+						@fieldValue(value.as[String])
+					</td>
+				} else {
+					<tr>
+						<td class="field-value"></td>
+						<td class="field-value">
+							@fieldValue(value.as[String])
+						</td>
+					</tr>
+				}
+			}
+	</tr>
+}


### PR DESCRIPTION
Extract common code to create table rows into tag

Based on unmerged `9-labels` branch.

Will resolve #25.