### PR TITLE
Fix ID for VD17-Einblattdrucke, add missing collection descriptions

### DIFF
--- a/conf/missing_collections.json
+++ b/conf/missing_collections.json
@@ -1,0 +1,92 @@
+[
+   {
+      "id":"http://digitalisiertedrucke.de/collections/juedische_periodika.rwth.ac.de",
+      "type": "http://purl.org/dc/dcmitype/Collection",
+      "isPartOf": "http://digitalisiertedrucke.de/collections",
+      "creator":[
+         {
+            "name":"Lehr- und Forschungsgebiet Deutsch-Jüdische Literaturgeschichte, RWTH Aachen",
+            "url":"https://www.germlit.rwth-aachen.de/"
+         },
+         {
+            "name":"Univeritätsbibliothek Johann Christian Senckenberg, Frankfurt a.M.; Bibliothek Germania",
+            "url":"https://www.ub.uni-frankfurt.de/"
+         }
+      ],
+      "language": "http://id.loc.gov/vocabulary/iso639-1/de",
+      "title":"Compact Memory",
+      "homepage":"http://www.compactmemory.de/"
+   },
+   {
+      "id":"http://digitalisiertedrucke.de/collections/sammlung_ponickau.ulb.hal.de",
+      "type": "http://purl.org/dc/dcmitype/Collection",
+      "isPartOf": "http://digitalisiertedrucke.de/collections",
+      "creator":{
+         "name":"Universitäts- und Landesbibliothek Sachsen-Anhalt (Halle an der Saale)",
+         "url":"http://bibliothek.uni-halle.de/"
+      },
+      "language": "http://id.loc.gov/vocabulary/iso639-1/de",
+      "title":"Sammlung Ponickau",
+      "homepage":"http://bibliothek.uni-halle.de/dbib/digital/historische_drucke/sammlung_ponickau/"
+   },
+   {
+      "id":"http://digitalisiertedrucke.de/collections/sozialistische_monatshefte.fes.bn.de",
+      "type": "http://purl.org/dc/dcmitype/Collection",
+      "isPartOf": "http://digitalisiertedrucke.de/collections",
+      "creator":{
+         "name":"Friedrich Ebert Stiftung Bonn",
+         "url":"http://www.fes.de/"
+      },
+      "language": "http://id.loc.gov/vocabulary/iso639-1/de",
+      "title":"Sozialistische Monatshefte",
+      "homepage":"http://library.fes.de/sozmon/"
+   },
+   {
+      "id":"http://digitalisiertedrucke.de/collections/digitale_sammlungen.uni.bn.de ",
+      "type": "http://purl.org/dc/dcmitype/Collection",
+      "isPartOf": "http://digitalisiertedrucke.de/collections",
+      "creator":{
+         "name":"Universitäts- und Landesbibliothek Bonn",
+         "url":"https://www.ulb.uni-bonn.de/"
+      },
+      "language": "http://id.loc.gov/vocabulary/iso639-1/de",
+      "title":"Digitale Sammlungen der ULB Bonn",
+      "homepage":"http://s2w.hbz-nrw.de/ulbbn"
+   },
+   {
+      "id":"http://digitalisiertedrucke.de/collections/die_arbeit.fes.bn.de",
+      "type": "http://purl.org/dc/dcmitype/Collection",
+      "isPartOf": "http://digitalisiertedrucke.de/collections",
+      "creator":{
+         "name":"Friedrich Ebert Stiftung, Bonn",
+         "url":"http://www.fes.de/"
+      },
+      "language": "http://id.loc.gov/vocabulary/iso639-1/de",
+      "title":"Die Arbeit. Zeitschrift für Gewerkschaftspolitik und Wirtschaftskunde",
+      "homepage":"http://library.fes.de/arbeit/"
+   },
+   {
+      "id":"http://digitalisiertedrucke.de/collections/digiwunsch.sub.goe.de",
+      "type": "http://purl.org/dc/dcmitype/Collection",
+      "isPartOf": "http://digitalisiertedrucke.de/collections",
+      "creator":{
+         "name":"Niedersächsische Staats- und Universitätsbibliothek Göttingen",
+         "url":"https://www.sub.uni-goettingen.de/"
+      },
+      "language": "http://id.loc.gov/vocabulary/iso639-1/de",
+      "title":"DigiWunschbuch",
+      "homepage":"http://digiwunschbuch.sub.uni-goettingen.de"
+   },
+   {
+      "id":"http://digitalisiertedrucke.de/collections/zvdd.gbv.goe.de",
+      "type": "http://purl.org/dc/dcmitype/Collection",
+      "isPartOf": "http://digitalisiertedrucke.de/collections",
+      "creator":{
+         "name":"Niedersächsische Staats- und Universitätsbibliothek Göttingen",
+         "url":"https://www.sub.uni-goettingen.de/"
+      },
+      "language": "http://id.loc.gov/vocabulary/iso639-1/de",
+      "title":"Zentrales Verzeichnis Digitalisierter Drucke (ZVDD)",
+      "homepage":"http://www.zvdd.de/"
+   }
+]

--- a/conf/morph_zvdd-title-digital2ld.xml
+++ b/conf/morph_zvdd-title-digital2ld.xml
@@ -30,13 +30,14 @@
 						<constant value="http://digitalisiertedrucke.de/collections/verteilte_rechtsquellen.ddb.f.de"/>
 				</data>
 				<data source="0248 .p" name="isPartOf">
-					<equals string="collection:einblattdrucke_vd17.gbv.goe.de"/>
-					<constant value="http://digitalisiertedrucke.de/collections/einblattdrucke.vd17.oo.de"/>
+						<equals string="collection:einblattdrucke_vd17.gbv.goe.de"/>
+						<constant value="http://digitalisiertedrucke.de/collections/einblattdrucke.vd17.oo.de"/>
 				</data>
 				<data source="0248 .p" name="isPartOf">
 						<not-equals string="collection:exilzeitschriften.d-nb.f.de"/>
 						<not-equals string="collection:juedische_periodika.d-nb.f.de"/>
 						<not-equals string="collection:verteilte_rechtsquellen.d-nb.f.de"/>
+						<not-equals string="collection:einblattdrucke_vd17.gbv.goe.de"/>
 						<regexp match="collection:(.*)" format="http://digitalisiertedrucke.de/collections/${1}"/>
 				</data>
 				<!-- TODO: If target a pdf, serve file via HTTP accept header -->

--- a/conf/morph_zvdd-title-digital2ld.xml
+++ b/conf/morph_zvdd-title-digital2ld.xml
@@ -30,6 +30,10 @@
 						<constant value="http://digitalisiertedrucke.de/collections/verteilte_rechtsquellen.ddb.f.de"/>
 				</data>
 				<data source="0248 .p" name="isPartOf">
+					<equals string="collection:einblattdrucke_vd17.gbv.goe.de"/>
+					<constant value="http://digitalisiertedrucke.de/collections/einblattdrucke.vd17.oo.de"/>
+				</data>
+				<data source="0248 .p" name="isPartOf">
 						<not-equals string="collection:exilzeitschriften.d-nb.f.de"/>
 						<not-equals string="collection:juedische_periodika.d-nb.f.de"/>
 						<not-equals string="collection:verteilte_rechtsquellen.d-nb.f.de"/>


### PR DESCRIPTION
Fixes #32.

Includes fix re. [this comment](https://github.com/hbz/digitalisiertedrucke/issues/32#issuecomment-256020938):  

> For two collections there is no description, though: collection:einblattdrucke_vd17.gbv.goe.de & collections:zvdd.hbz.k.de. The first probably is an error and we should use collection:einblattdrucke.vd17.oo.de instead (see also https://github.com/lobid/lodmill/blob/master/lodmill-rd/transformations/zvdd/statistic/mismatching_collection-IDs.textile).
